### PR TITLE
fix declaration of CALLBACK_USB_GetDescriptor

### DIFF
--- a/Descriptors.c
+++ b/Descriptors.c
@@ -154,7 +154,7 @@ const USB_Descriptor_String_t PROGMEM ProductString      = USB_STRING_DESCRIPTOR
 // USB Device Callback - Get Descriptor
 uint16_t CALLBACK_USB_GetDescriptor(
 	const uint16_t wValue,
-	const uint8_t wIndex,
+	const uint16_t wIndex,
 	const void** const DescriptorAddress
 ) {
 	const uint8_t  DescriptorType   = (wValue >> 8);

--- a/Descriptors.h
+++ b/Descriptors.h
@@ -49,7 +49,7 @@ enum StringDescriptors_t
 // Function Prototypes
 uint16_t CALLBACK_USB_GetDescriptor(
 	const uint16_t wValue,
-	const uint8_t wIndex,
+	const uint16_t wIndex,
 	const void** const DescriptorAddress
 ) ATTR_WARN_UNUSED_RESULT ATTR_NON_NULL_PTR_ARG(3);
 


### PR DESCRIPTION
fix declaration of `CALLBACK_USB_GetDescriptor`
https://github.com/progmem/Switch-Fightstick/issues/10